### PR TITLE
Improve Dockerfile and Docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
-FROM docker.atixlabs.com/node:14.5.0-alpine as nodejs-builder
+ARG UBUNTU_VERSION=20.04
+
+FROM ubuntu:${UBUNTU_VERSION} as ubuntu-nodejs
+ARG NODEJS_MAJOR_VERSION=14
+ENV DEBIAN_FRONTEND=nonintercative
+RUN apt-get update && apt-get install curl -y &&\
+  curl --proto '=https' --tlsv1.2 -sSf -L https://deb.nodesource.com/setup_${NODEJS_MAJOR_VERSION}.x | bash - &&\
+  apt-get install nodejs -y
+
+FROM ubuntu-nodejs as nodejs-builder
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&\
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&\
+  apt-get update && apt-get install gcc g++ make gnupg2 yarn -y
 
 # Copy deps
 FROM nodejs-builder as mcs-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
         max-size: '200k'
         max-file: '10'
   multisig-coordination-server:
-    image: node:14.5.0-alpine
+    build:
+      context: .
+      target: mcs
+    image: inputoutput/multisig-coordination-server
     environment:
       - DB_CONNECTION_STRING=postgresql://postgres:notForProduction!@postgres:5432/cexplorer
       - LOGGER_LEVEL=debug
@@ -34,7 +37,6 @@ services:
       - CRON_EXPRESSION="0 0 * * *"
       - MESSAGE_SIZE=128
       - PRUNING_TIME=2
-    command: bash -c "yarn --offline && yarn dev"
     expose:
       - 8080
     ports:
@@ -45,8 +47,6 @@ services:
         max-size: '200k'
         max-file: '10'
     working_dir: /home/node/app
-    volumes:
-      - ./:/home/node/app
 secrets:
   postgres_db:
     file: ./config/secrets/postgres_db


### PR DESCRIPTION
chore: docker-compose uses the docker file and doesn't mount anything extra - Closes: #4
chore: Dockerfile uses ubuntu as base image - Closes: #21